### PR TITLE
Declutter rspec final output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---format documentation

--- a/app/presenters/groups_presenter.rb
+++ b/app/presenters/groups_presenter.rb
@@ -1,5 +1,5 @@
 class GroupsPresenter
-  def initialize(group: group, current_user: current_user)
+  def initialize(group:, current_user:)
     @group = group
     @current_user = current_user
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
   # Print the 2 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 2
+  # config.profile_examples = 2
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
- Use more compact `progress` formatter
- Don't output test performance benchmarks unless asked for
- Fix circular reference warnings
