### PR TITLE
Remove metaprogramming to improve readability.

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,13 +8,13 @@ class Group < ActiveRecord::Base
 
   def admin?(user)
     team.admin?(user) ||
-    memberships.where(user: user).any? { |m| m.admin? && m.approved? } ||
-    !!parent_group && parent_group.admin?(user)
+      memberships.where(user: user).any? { |m| m.admin? && m.approved? } ||
+      parent_group.present? && parent_group.admin?(user)
   end
 
   def member?(user)
     team.member?(user) ||
-    memberships.where(user: user).any? { |m| m.member? && m.approved? } ||
-    !!parent_group && parent_group.member?(user)
+      memberships.where(user: user).any? { |m| m.member? && m.approved? } ||
+      parent_group.present? && parent_group.member?(user)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,41 +1,20 @@
 class Group < ActiveRecord::Base
   include Joinable
 
-  belongs_to :parent_group, class_name: 'Group', foreign_key: :group_id
   belongs_to :team
-
+  belongs_to :parent_group, class_name: 'Group', foreign_key: :group_id
+  has_many :subgroups, class_name: 'Group'
   has_and_belongs_to_many :skills
 
-  has_many :subgroups, class_name: 'Group'
+  def admin?(user)
+    team.admin?(user) ||
+    memberships.where(user: user).any? { |m| m.admin? && m.approved? } ||
+    !!parent_group && parent_group.admin?(user)
+  end
 
-  [:admin, :member].each do |membership_type|
-    has_membership = "#{membership_type}?".to_sym
-    has_team_membership = "team_#{membership_type}?".to_sym
-    has_self_membership = "self_#{membership_type}?".to_sym
-    has_parent_group_membership = "parent_group_#{membership_type}?".to_sym
-
-    define_method has_membership do |user|
-      send(has_self_membership, user) ||
-        send(has_team_membership, user) ||
-        send(has_parent_group_membership, user) ||
-        false
-    end
-
-    define_method has_team_membership do |user|
-      team.send(has_membership, user)
-    end
-    private has_team_membership
-
-    define_method has_self_membership do |user|
-      memberships.where(user: user).any? do |membership|
-        membership.send(has_membership) && membership.approved?
-      end
-    end
-    private has_self_membership
-
-    define_method has_parent_group_membership do |user|
-      parent_group && parent_group.send(has_membership, user)
-    end
-    private has_parent_group_membership
+  def member?(user)
+    team.member?(user) ||
+    memberships.where(user: user).any? { |m| m.member? && m.approved? } ||
+    !!parent_group && parent_group.member?(user)
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -11,13 +11,11 @@ class Team < ActiveRecord::Base
     end
   end
 
-  [:admin, :member].each do |membership_type|
-    has_membership = "#{membership_type}?".to_sym
+  def admin?(user)
+    memberships.where(user: user).any? { |m| m.admin? && m.approved? }
+  end
 
-    define_method has_membership do |user|
-      memberships.where(user: user).any? do |membership|
-        membership.send(has_membership) && membership.approved?
-      end
-    end
+  def member?(user)
+    memberships.where(user: user).any? { |m| m.member? && m.approved? }
   end
 end


### PR DESCRIPTION
I think this metaprogramming is going to get us into more trouble than it's worth. It's a very heavy hammer and can be very useful for more complex problems. However, here it's used only to remove a small amount of duplication, which comes at the cost of the class's readability.
